### PR TITLE
Remove client app code from sonarcloud analysis

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,22 +5,26 @@ sonar.projectName=Wizard
 sonar.projectVersion=1.0
 
 sonar.binaries=./app/build/intermediates/javac
-sonar.java.binaries=./app/build/intermediates/javac/debug/classes,./WizardServer/build/classes/java/main,./libnetwork/build/classes/java/main
-sonar.java.test.binaries=./app/build/intermediates/javac/debugUnitTest,./WizardServer/build/classes/java/test,./libnetwork/build/classes/java/test
+sonar.java.binaries=./WizardServer/build/classes/java/main,./libnetwork/build/classes/java/main
+# sonar.java.binaries=./app/build/intermediates/javac/debug/classes,./WizardServer/build/classes/java/main,./libnetwork/build/classes/java/main
+sonar.java.test.binaries=./WizardServer/build/classes/java/test,./libnetwork/build/classes/java/test
+# sonar.java.test.binaries=./app/build/intermediates/javac/debugUnitTest,./WizardServer/build/classes/java/test,./libnetwork/build/classes/java/test
 
 # set java version
 sonar.java.source=8
 
 # Path is relative to the sonar-project.properties file. Replace "BACKSLASH" by "SLASH" on Windows.
 # This property is optional if sonar.modules is set.
-sonar.sources=./app/src/main/java,./libnetwork/src/main/java,./WizardServer/src/main/java
-sonar.test=./app/src/androidTest/java,./app/src/test/java,./libnetwork/src/test/java,./WizardServer/src/test/java
+sonar.sources=./libnetwork/src/main/java,./WizardServer/src/main/java
+# sonar.sources=./app/src/main/java,./libnetwork/src/main/java,./WizardServer/src/main/java
+sonar.test=./libnetwork/src/test/java,./WizardServer/src/test/java
+# sonar.test=./app/src/androidTest/java,./app/src/test/java,./libnetwork/src/test/java,./WizardServer/src/test/java
 
 # use some plugin to recognize test results
 sonar.junit.reportPaths=./WizardServer/build/test-results/test,./libnetwork/build/test-results/test
 # sonar.junit.reportPaths=./app/build/test-results/testDebugUnitTest,./WizardServer/build/test-results/test,./libnetwork/build/test-results/test
 
-sonar.jacoco.reportPaths=./app/build/jacoco/testDebugUnitTest.exec
+# sonar.jacoco.reportPaths=./app/build/jacoco/testDebugUnitTest.exec
 sonar.coverage.jacoco.xmlReportPaths=./WizardServer/build/reports/jacoco/test/jacocoTestReport.xml,./libnetwork/build/reports/jacoco/test/jacocoTestReport.xml
 # sonar.coverage.jacoco.xmlReportPaths=./app/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml,./WizardServer/build/reports/jacoco/test/jacocoTestReport.xml,./libnetwork/build/reports/jacoco/test/jacocoTestReport.xml
 sonar.androidLint.reportPaths=./app/build/reports/lint-results.xml


### PR DESCRIPTION
Fixes: coverage displayed only for the parts we care about, this time for real.

We can still decide if we want to merge. I just made the PR to have it ready.
